### PR TITLE
security doc: formatting fixes

### DIFF
--- a/documentation/core/security.asciidoc
+++ b/documentation/core/security.asciidoc
@@ -31,30 +31,23 @@ current authenticated user.
 Security Handlers
 -----------------
 
-Security within Undertow is implemented as a set of handlers and a set of authentication
-mechanisms co-ordinated by these handles.
+Security within Undertow is implemented as a set of asynchronous handlers and a set of authentication
+mechanisms co-ordinated by these handlers.
 
 Early in the call chain is a handler called `SecurityInitialHandler`, this is where the security processing
 beings, this handler ensures that an empty `SecurityContext` is set on the current `HttpServerExchange`
-Security within Undertow is implemented as a set of asynchronous handlers and a set of authentication
-mechanisms co-ordinated by these handles.
 
 * Allow authentication to occur in the call as early as possible.
 * Allows for use of the mechanisms in numerous scenarios and not just for servlets.
 
-Early in the call chain is a handler called `SecurityInitialHandler`, this is where the security processing
-beings, this handler creates a new SecurityContext and sets it on the exchange (overwriting any previous
-security context).
-
 The `SecurityContext` is responsible for both holding the state related to the currently authenticated user
-and also for holding the configured `AuthenticationMechanism`s and providing methods to work with both of
-these.  As this `SecurityContext` is replacable and restorable then advanced configurations can be
-achieve where a general configuration can be applied to a complete server with custom configuration
-replacing it later in the call.
+and also for holding the configured mechanisms for authentication (`AuthenticationMechanism`) and providing 
+methods to work with both of these. As this `SecurityContext` is replacable a general configuration
+can be applied to a complete server with custom configuration replacing it later in the call.
 
-After the `SecurityContext` has been established subseqeunt handlers can then add `AuthenticationMechanism`s
+After the `SecurityContext` has been established subseqeunt handlers can then add authentication mechanisms
 to the context, to simplify this Undertow contains a handler called `AuthenticationMechanismsHandler`
-this handler can be created with a set of `AuthenticationMechanism`s and will set them all on the
+this handler can be created with a set of `AuthenticationMechanism` mechanisms and will set them all on the
 established `SecurityContext`.  Alternatively custom handlers could be used to add mechanisms one at a time
 bases on alternative requirements.
 
@@ -69,9 +62,9 @@ on any identified constraint this will either mandate authentication or only per
 if appropriate for the configured mechanisms.
 
 There is no requirement for these handlers to be executed consecutively, the only requirement is that first
-the `SecurityContext` is established, then the `AuthenticationMechanism`s and constrain check can be
-performed in any order and finally the `AuthenticationCallHandler` but be called before any processing of
-a potentially protected resource.
+the `SecurityContext` is established, then the authentications and constrain check can be
+performed in any order and finally the `AuthenticationCallHandler` must be used before any processing of
+a potentially protected resource is called.
 
 image::security_handlers.png["An Example Security Chain",title="An Example Security Chain"]
 
@@ -113,7 +106,7 @@ required is for a few reasons:
 When authentication runs the `authenticate` method on each configured `AuthenticationMechanism` is called in turn, this continues
 until one of the following occurs:
 
-* A mechanisms successfully authenticates the request and returns `AUTHENTICATED`.
+* A mechanism successfully authenticates the request and returns `AUTHENTICATED`.
 * A mechanism attempts but does not complete authentication and returns `NOT_AUTHENTICATED`.
 * The list of mechanisms is exhausted.
 


### PR DESCRIPTION
asciidoc requires a blank after backticks. Working around the plural form of the class. Also replaced a but with must to make more sense. Removed some duplication.

Signed-off-by: Bernd Eckenfels
